### PR TITLE
docs: add Guidelines 8-10 from LangChain harness engineering research

### DIFF
--- a/docs/agent_tool_desig_guidelines.md
+++ b/docs/agent_tool_desig_guidelines.md
@@ -1,6 +1,6 @@
 # Agent Tool Design Guidelines
-### Synthesized from "Lessons from Building Claude Code"
-*Alex Chen — March 5, 2026*
+### Synthesized from "Lessons from Building Claude Code" + LangChain Harness Engineering (2026)
+*Alex Chen — March 5, 2026 · Updated March 16, 2026*
 
 ---
 
@@ -41,6 +41,8 @@ The #1 mistake in agent tool design is giving every model the same interface. To
 **Solution:** Maintain a small, well-chosen model set and audit your tools against their actual capabilities quarterly. Ask: "Does this tool still help the model, or does it now constrain it?"
 
 **Rule:** Tools have a lifecycle. Provision, validate, evolve, and retire them deliberately.
+
+**Upgrade — Trace-Driven Iteration:** Quarterly audits are the floor, not the ceiling. The fastest improvement loop is: run agent on benchmark → collect traces → spawn parallel error-analysis agents → synthesise failure patterns → make targeted harness changes → re-run. LangChain improved their coding agent 13.7 points on Terminal Bench 2.0 this way *without changing the model*. Every agent failure is a training signal for the harness.
 
 ---
 
@@ -97,6 +99,73 @@ The #1 mistake in agent tool design is giving every model the same interface. To
 
 ---
 
+---
+
+## Guideline 8: Force Agents to Verify Their Own Work Before Exiting
+
+**Problem:** Agents are biased toward their first plausible solution. The most common failure pattern is: write code → re-read it → "looks right" → exit. They never run tests, never compare output against the original spec. They validate against their own implementation rather than the task requirements.
+
+**Solution:** Add a pre-completion hook that intercepts the agent before it exits and forces a verification pass. This is not optional guidance in a system prompt — it must be mechanically enforced by the harness:
+
+1. **Plan:** Read the task spec, identify how success will be verified
+2. **Build:** Implement with testing in mind
+3. **Verify:** Run tests, compare output against the *original spec* (not your own code)
+4. **Fix:** If anything fails, return to Build — do not skip to exit
+
+The hook should only allow exit once verification has been attempted. A `hasRunVerification` flag in agent state prevents double-triggering.
+
+**Why it works:** Models are exceptional self-improvement machines *when given a concrete signal to improve against*. Tests provide that signal. Without them, the agent has no feedback loop within the run.
+
+**Rule:** Verification is not a suggestion. Make it structurally impossible for the agent to exit without attempting it.
+
+**References:** LangChain `PreCompletionChecklistMiddleware`; [Ralph Wiggum Loop](https://ghuntley.com/loop/)
+
+---
+
+## Guideline 9: Onboard Agents Into Their Environment at Boot
+
+**Problem:** Agents waste significant early turns on environment discovery — finding file paths, checking which tools are installed, mapping directory structure. This is error-prone (search tools fail, paths are wrong) and burns context budget on work that could be done once at startup.
+
+**Solution:** Inject environment context at agent boot via a startup hook, not through the system prompt:
+
+- **Directory map:** Current working directory + key subdirectories + file counts
+- **Available tools:** Which CLIs are installed and their versions (python, node, cargo, go, etc.)
+- **Constraints:** Timeouts, memory limits, evaluation criteria, testing framework in use
+- **Task context:** How the work will be scored or verified (especially important for benchmark-style tasks)
+
+The more agents know about their environment *before* they start, the fewer early-turn errors. LangChain's `LocalContextMiddleware` reduced their "context discovery failure" rate significantly — agents that know their environment from step 1 don't waste 10 turns figuring out where things are.
+
+**Important:** This is context *delivery*, not context *dumping*. Inject structured, factual environment data — not prose guidance, which belongs in the system prompt.
+
+**Rule:** Boot-time environment injection is cheap and high-leverage. Do it before the first model call, not after the first failure.
+
+---
+
+## Guideline 10: Detect and Break Doom Loops
+
+**Problem:** Agents get stuck making small variations to the same broken approach — sometimes 10+ times on the same file. They are myopic once committed to a plan: each iteration feels like progress ("I fixed the indentation") when the fundamental approach is wrong. This burns tokens, time, and produces no progress.
+
+**Solution:** Track per-resource edit counts and inject reconsidering context after a threshold is crossed:
+
+```
+You have edited 'src/parser.ts' 6 times. Consider stepping back:
+is your fundamental approach correct? Review the original spec
+and try a different strategy rather than making further small edits.
+```
+
+Triggers to track:
+| Signal | Threshold | Intervention |
+|--------|-----------|-------------|
+| Same file edited N times | 5 (configurable) | Suggest reconsidering approach |
+| Same tool called with identical args | 3 consecutive | Flag repetition, suggest alternative |
+| Same error message seen | 3 times | Prompt root cause analysis, not patch |
+
+**Design note:** This is a guardrail for *today's* models. As models improve, doom loops will become rarer and this hook can be retired. Build it as a modular, removable component — not baked into core agent logic. The goal is correct behaviour now without coupling future architecture to current model limitations.
+
+**Rule:** A loop detector doesn't fix the underlying problem — it creates an opening for the agent to escape. Make the intervention prompt Socratic, not prescriptive.
+
+---
+
 ## Summary: The Agent Design Checklist
 
 Before shipping any tool or skill change:
@@ -108,8 +177,13 @@ Before shipping any tool or skill change:
 - [ ] Have you measured model affinity (call frequency) in addition to output quality?
 - [ ] Is the total tool count still at or below your ceiling?
 - [ ] Do you have a plan to revisit this tool as model capabilities change?
+- [ ] Does the harness force a verification pass before the agent exits? (G8)
+- [ ] Is environment context injected at boot, not discovered at runtime? (G9)
+- [ ] Is there a loop detector to break repeated-edit doom loops? (G10)
+- [ ] Are agent traces collected and feeding back into harness improvements? (G3 upgrade)
 
 ---
 
 *Based on: @trq212's "Lessons from Building Claude Code"*
+*Updated with: LangChain ["Improving Deep Agents with Harness Engineering"](https://blog.langchain.com/improving-deep-agents-with-harness-engineering/) (2026)*
 *Author: Alex Chen*


### PR DESCRIPTION
## Summary

Adds 3 new guidelines and upgrades G3, based on LangChain's harness engineering research that took their coding agent from **52.8% → 66.5%** on Terminal Bench 2.0 — harness changes only, model unchanged.

**Source:** https://blog.langchain.com/improving-deep-agents-with-harness-engineering/

---

## Changes

### Guideline 8 — Force agents to verify their own work before exiting
The most common failure pattern: agent writes solution, re-reads own code, "looks right", exits. Never runs tests. Never compares against spec. Fix: a pre-completion hook that mechanically prevents exit without a verification pass. Based on LangChain's `PreCompletionChecklistMiddleware` and the [Ralph Wiggum Loop](https://ghuntley.com/loop/) pattern.

### Guideline 9 — Onboard agents into their environment at boot
Agents waste early turns on environment discovery (finding paths, checking tool installs). Boot-time context injection via a startup hook eliminates this class of errors before the first model call. Based on LangChain's `LocalContextMiddleware`.

### Guideline 10 — Detect and break doom loops
Agents commit to a broken approach and make 10+ small variations to the same file. Track per-resource edit counts; inject a Socratic reconsidering prompt after threshold. Designed as a modular, removable guardrail — expected to become unnecessary as models improve. Based on LangChain's `LoopDetectionMiddleware`.

### G3 upgrade — Trace-driven iteration
Added trace analysis as a first-class improvement loop alongside quarterly audits: collect traces → parallel error-analysis agents → synthesise patterns → targeted harness changes → re-run.

### Checklist
Added 4 new items to the pre-ship checklist covering G8–G10 and trace feedback.

---

## What was deliberately excluded

**Reasoning budget tuning** (xhigh→high→xhigh sandwich) — too model-specific. Will be wrong advice in 6 months. Not added.