### PR TITLE
chore: verify CI gates fire cleanly with Node.js 24 env var

### DIFF
--- a/harness_skills/cli/main.py
+++ b/harness_skills/cli/main.py
@@ -150,6 +150,8 @@ def cli() -> None:
     """
 
 
+# Register all 17 sub-commands. See docs/cli/index.md for the
+# command reference and per-command pages under docs/cli/<cmd>.md.
 cli.add_command(audit_cmd)
 cli.add_command(boot_cmd)
 cli.add_command(completion_report_cmd)


### PR DESCRIPTION
## Summary

Two-line comment-only addition to `harness_skills/cli/main.py` to exercise the seven PR-side workflow gates whose Node.js 24 env-var change (`61a4e12`) hasn't been validated end-to-end yet.

Pushes to `main` don't fire `pull_request`-triggered workflows; opening a PR is the only way to confirm the env var (now present in all 9 workflow files) actually silences the deprecation warning across every gate.

## What to verify

For each PR-side gate, in the run log:
- ✅ Step env shows `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
- ✅ No `Node.js 20 actions are deprecated` warning emitted
- ✅ Gate completes (status doesn't matter for advisory ones; we just need them to *run*)

## Disposition

If green, this is safe to merge — the comment is genuinely useful documentation. If you'd rather, close without merging and revert the local branch.