### PR TITLE
fix(cli): pass package_name to click.version_option

### DIFF
--- a/harness_skills/cli/main.py
+++ b/harness_skills/cli/main.py
@@ -137,7 +137,7 @@ class PipelineGroup(click.Group):
 
 
 @click.group(cls=PipelineGroup)
-@click.version_option()
+@click.version_option(package_name="agent-harness-skills")
 def cli() -> None:
     """Harness Skills — agent harness engineering toolkit.
 

--- a/tests/test_cli/test_command_registration.py
+++ b/tests/test_cli/test_command_registration.py
@@ -121,3 +121,9 @@ class TestCommandHelp:
     def test_update_help(self) -> None:
         result = self.runner.invoke(cli, ["update", "--help"])
         assert result.exit_code == 0
+
+    def test_version_flag(self) -> None:
+        result = self.runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0, result.output
+        assert result.exception is None
+        assert "version" in result.output.lower()


### PR DESCRIPTION
## Summary

- `harness --version` crashed with `RuntimeError: 'harness_skills' is not installed`. Click's auto-detection used the import-package name (`harness_skills`) but the distribution name is `agent-harness-skills`.
- Pass `package_name="agent-harness-skills"` explicitly to `click.version_option`.
- Add a regression test in `tests/test_cli/test_command_registration.py`.

Closes #5

## Test plan

- [x] `pytest tests/test_cli/test_command_registration.py` — 21/21 pass
- [x] `harness --version` returns exit 0 and prints `cli, version 0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)